### PR TITLE
Add pageSize to the CLI arguments

### DIFF
--- a/src/adminApi.js
+++ b/src/adminApi.js
@@ -6,27 +6,28 @@ let pluginSchemasCache;
 let kongVersionCache;
 let resultsCache = {};
 
-export default ({host, https, ignoreConsumers, cache}) => {
+export default ({host, https, ignoreConsumers, cache, pageSize}) => {
     const router = createRouter(host, https);
 
     return createApi({
         router,
         ignoreConsumers,
         getPaginatedJson: cache ? getPaginatedJsonCache : getPaginatedJson,
+        pageSize: pageSize
     });
 }
 
-function createApi({ router, getPaginatedJson, ignoreConsumers }) {
+function createApi({ router, getPaginatedJson, ignoreConsumers, pageSize }) {
     return {
         router,
-        fetchApis: () => getPaginatedJson(router({name: 'apis'})),
-        fetchGlobalPlugins: () => getPaginatedJson(router({name: 'plugins'})),
-        fetchPlugins: apiId => getPaginatedJson(router({name: 'api-plugins', params: {apiId}})),
-        fetchConsumers: () => ignoreConsumers ? Promise.resolve([]) : getPaginatedJson(router({name: 'consumers'})),
-        fetchConsumerCredentials: (consumerId, plugin) => getPaginatedJson(router({name: 'consumer-credentials', params: {consumerId, plugin}})),
-        fetchConsumerAcls: (consumerId) => getPaginatedJson(router({name: 'consumer-acls', params: {consumerId}})),
-        fetchUpstreams: () => getPaginatedJson(router({name: 'upstreams'})),
-        fetchTargets: (upstreamId) => getPaginatedJson(router({name: 'upstream-targets-active', params: {upstreamId}})),
+        fetchApis: () => getPaginatedJson(router({name: 'apis'}), pageSize),
+        fetchGlobalPlugins: () => getPaginatedJson(router({name: 'plugins'}), pageSize),
+        fetchPlugins: apiId => getPaginatedJson(router({name: 'api-plugins', params: {apiId}}), pageSize),
+        fetchConsumers: () => ignoreConsumers ? Promise.resolve([]) : getPaginatedJson(router({name: 'consumers'}), pageSize),
+        fetchConsumerCredentials: (consumerId, plugin) => getPaginatedJson(router({name: 'consumer-credentials', params: {consumerId, plugin}}), pageSize),
+        fetchConsumerAcls: (consumerId) => getPaginatedJson(router({name: 'consumer-acls', params: {consumerId}}), pageSize),
+        fetchUpstreams: () => getPaginatedJson(router({name: 'upstreams'}), pageSize),
+        fetchTargets: (upstreamId) => getPaginatedJson(router({name: 'upstream-targets-active', params: {upstreamId}}), pageSize),
 
         // this is very chatty call and doesn't change so its cached
         fetchPluginSchemas: () => {
@@ -34,7 +35,7 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
                 return Promise.resolve(pluginSchemasCache);
             }
 
-            return getPaginatedJson(router({name: 'plugins-enabled'}))
+            return getPaginatedJson(router({name: 'plugins-enabled'}), pageSize)
                 .then(json => Promise.all(getEnabledPluginNames(json.enabled_plugins).map(plugin => getPluginScheme(plugin, plugin => router({name: 'plugins-scheme', params: {plugin}})))))
                 .then(all => pluginSchemasCache = new Map(all));
         },
@@ -43,7 +44,7 @@ function createApi({ router, getPaginatedJson, ignoreConsumers }) {
                 return Promise.resolve(kongVersionCache);
             }
 
-            return getPaginatedJson(router({name: 'root'}))
+            return getPaginatedJson(router({name: 'root'}), pageSize)
                 .then(json => Promise.resolve(json.version))
                 .then(version => kongVersionCache = parseVersion(version));
         },
@@ -62,24 +63,24 @@ function getEnabledPluginNames(enabledPlugins) {
   return enabledPlugins;
 }
 
-function getPaginatedJsonCache(uri) {
+function getPaginatedJsonCache(uri, pageSize) {
     if (resultsCache.hasOwnProperty(uri)) {
         return resultsCache[uri];
     }
 
-    let result = getPaginatedJson(uri);
+    let result = getPaginatedJson(uri, pageSize);
     resultsCache[uri] = result;
 
     return result;
 }
 
 function getPluginScheme(plugin, schemaRoute) {
-    return getPaginatedJson(schemaRoute(plugin))
+    return getPaginatedJson(schemaRoute(plugin), null)
         .then(({fields}) => [plugin, fields]);
 }
 
-function getPaginatedJson(uri) {
-    return requester.get(uri)
+function getPaginatedJson(uri, pageSize) {
+    return requester.get(uri, pageSize) 
     .then(response => {
       if (!response.ok) {
           const error = new Error(`${uri}: ${response.status} ${response.statusText}`);
@@ -95,12 +96,12 @@ function getPaginatedJson(uri) {
         if (!json.data) return json;
         if (!json.next) return json.data;
 
-        if (json.data.length < 100) {
+        if (json.data.length < pageSize) {
             // FIXME an hopeful hack to prevent a loop
             return json.data;
         }
 
-        return getPaginatedJson(json.next).then(data => json.data.concat(data));
+        return getPaginatedJson(json.next, null).then(data => json.data.concat(data));
     });
 }
 

--- a/src/cli-apply.js
+++ b/src/cli-apply.js
@@ -15,6 +15,7 @@ program
     .option('--https', 'Use https for admin API requests')
     .option('--no-cache', 'Do not cache kong state in memory')
     .option('--ignore-consumers', 'Do not sync consumers')
+    .option('--page-size <value>', 'Page size for get requests', null, 100)
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
     .parse(process.argv);
@@ -68,7 +69,7 @@ else {
 
 console.log(`Apply config to ${host}`.green);
 
-execute(config, adminApi({host, https, ignoreConsumers, cache}), screenLogger)
+execute(config, adminApi({host, https, ignoreConsumers, cache, pageSize: program.pageSize}), screenLogger)
   .catch(error => {
       console.error(`${error}`.red, '\n', error.stack);
       process.exit(1);

--- a/src/cli-dump.js
+++ b/src/cli-dump.js
@@ -14,6 +14,7 @@ program
     .option('--host <value>', 'Kong admin host (default: localhost:8001)', 'localhost:8001')
     .option('--https', 'Use https for admin API requests')
     .option('--ignore-consumers', 'Ignore consumers in kong')
+    .option('--page-size <value>', 'Page size for get requests', null, 100)
     .option('--header [value]', 'Custom headers to be added to all requests', (nextHeader, headers) => { headers.push(nextHeader); return headers }, [])
     .option('--credential-schema <value>', 'Add custom auth plugin in <name>:<key> format. Ex: custom_jwt:key. Repeat option for multiple custom plugins', repeatableOptionCallback, [])
     .parse(process.argv);
@@ -31,12 +32,13 @@ try {
 }
 
 let headers = program.header || [];
+let https = program.https || false;
 
 headers
     .map((h) => h.split(':'))
     .forEach(([name, value]) => requester.addHeader(name, value));
 
-readKongApi(adminApi({ host: program.host, https: program.https, ignoreConsumers: program.ignoreConsumers }))
+readKongApi(adminApi({ host: program.host, https: https, ignoreConsumers: program.ignoreConsumers, pageSize: program.pageSize }))
     .then(results => {
         return {host: program.host, https: program.https, headers, ...results};
     })

--- a/src/requester.js
+++ b/src/requester.js
@@ -5,7 +5,7 @@ let headers = {};
 const addHeader = (name, value) => { headers[name] = value };
 const clearHeaders = () => { headers = {} };
 
-const get = (uri) => {
+const get = (uri, pageSize) => {
     const options = {
         method: 'GET',
         headers: {
@@ -14,7 +14,11 @@ const get = (uri) => {
         }
     };
 
-    return request(uri, options);
+    var modifiedUri = uri;
+    if (pageSize) {
+      modifiedUri = uri + '/?size=' + pageSize;
+    }
+    return request(modifiedUri, options);
 };
 
 const request = (uri, opts) => {


### PR DESCRIPTION
Adding `pageSize` to the GET requests. The argument is passed as a CLI argument.

The tests pass locally. Also tested with our integration Kong with `--pageSize 1000`.